### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -72,6 +72,8 @@ jobs:
 
   packaging:
     name: Generate Build Artifacts
+    permissions:
+      contents: read
 
     strategy:
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/paazmaya/chinenshichanaka/security/code-scanning/2](https://github.com/paazmaya/chinenshichanaka/security/code-scanning/2)

To resolve this, add a `permissions:` block to the affected job (`packaging`), as recommended. This block should be placed at the same level as `name:` within the job to explicitly set `contents: read`, as the packaging job only needs to check out and read repository contents, not push or change them. This will prevent the GITHUB_TOKEN used by steps of the job from inheriting broader permissions and thus adheres to least privilege principles.

- Edit `.github/workflows/rust-ci.yml`
- Locate the `packaging:` job declaration and add a permissions block directly after the `name: Generate Build Artifacts` line (line 74).
- Add:  
  ```yaml
  permissions:
    contents: read
  ```
- No imports, variable or method definitions are needed as this is YAML config.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
