### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -8,6 +8,8 @@ jobs:
   testing:
     # https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/paazmaya/chinenshichanaka/security/code-scanning/1](https://github.com/paazmaya/chinenshichanaka/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block to the `testing` job in `.github/workflows/rust-ci.yml`. The minimal and recommended setting for most CI jobs is `contents: read`, unless the job requires additional access. In this workflow, the `testing` job appears only to check out code, run tests, and upload reports to external services (not requiring write access to GitHub). Therefore, a single permissions block granting only `contents: read` for the `testing` job is the best fix. Add this block at the same indentation level as `runs-on` inside the `testing` job (line 10), before `steps:` (line 12). No new imports or dependency changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
